### PR TITLE
Update Kotlin Gradle plugin to version 2.1.21

### DIFF
--- a/examples/google-auth-demo/src-tauri/gen/android/build.gradle.kts
+++ b/examples/google-auth-demo/src-tauri/gen/android/build.gradle.kts
@@ -5,7 +5,7 @@ buildscript {
     }
     dependencies {
         classpath("com.android.tools.build:gradle:8.11.0")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.25")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.21")
     }
 }
 


### PR DESCRIPTION
The example app's Kotlin Gradle plugin 1.9.25 cannot read metadata from libraries compiled with Kotlin 2.1, which current androidx releases ship with. Bump it to 2.1.21.