### PR TITLE
feat(desktop): support accessType and prompt options for offline access

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,14 +202,16 @@ const response = await signIn({
 
 ```typescript
 interface SignInOptions {
-  clientId: string;              // Required: Google OAuth client ID
-  clientSecret?: string;         // Required for desktop, Android web flow
-  scopes?: string[];             // OAuth scopes to request
-  hostedDomain?: string;         // Restrict authentication to a specific domain
-  loginHint?: string;            // Email hint to pre-fill in the sign-in form
-  redirectUri?: string;          // Custom redirect URI (desktop: localhost only)
-  successHtmlResponse?: string;  // Custom HTML shown after auth (desktop only)
-  flowType?: 'native' | 'web';   // Android only, default: 'native'. See ANDROID_SETUP.md
+    clientId: string;                  // Required: Google OAuth client ID
+    clientSecret?: string;             // Required for desktop, Android web     flow
+    scopes?: string[];                 // OAuth scopes to request
+    hostedDomain?: string;             // Restrict authentication to a  specific domain
+    loginHint?: string;                // Email hint to pre-fill in the     sign-in form
+    redirectUri?: string;              // Custom redirect URI (desktop:     localhost only)
+    successHtmlResponse?: string;      // Custom HTML shown after auth  (desktop only)
+    flowType?: 'native' | 'web';       // Android only, default: 'native'.  See ANDROID_SETUP.md
+    accessType?: 'offline' | 'online'; // Desktop only, default: 'online'.  Use 'offline' to get refreshToken
+    prompt?: 'none' | 'consent' | 'select_account' | 'consent select_account'
 }
 ```
 

--- a/guest-js/index.ts
+++ b/guest-js/index.ts
@@ -37,7 +37,8 @@ export interface SignInOptions {
   /** Authentication flow type (Android only, ignored on other platforms) */
   flowType?: "native" | "web";
   accessType?: 'online' | 'offline';
-  prompt?: 'none' | 'consent' | 'select_account';
+  accessType?: "online" | "offline";
+  prompt?: "none" | "consent" | "select_account";
 }
 
 /**

--- a/guest-js/index.ts
+++ b/guest-js/index.ts
@@ -36,6 +36,7 @@ export interface SignInOptions {
   successHtmlResponse?: string;
   /** Authentication flow type (Android only, ignored on other platforms) */
   flowType?: "native" | "web";
+  accessType?: 'online' | 'offline';
 }
 
 /**

--- a/guest-js/index.ts
+++ b/guest-js/index.ts
@@ -37,6 +37,7 @@ export interface SignInOptions {
   /** Authentication flow type (Android only, ignored on other platforms) */
   flowType?: "native" | "web";
   accessType?: 'online' | 'offline';
+  prompt?: 'none' | 'consent' | 'select_account';
 }
 
 /**

--- a/guest-js/index.ts
+++ b/guest-js/index.ts
@@ -36,10 +36,15 @@ export interface SignInOptions {
   successHtmlResponse?: string;
   /** Authentication flow type (Android only, ignored on other platforms) */
   flowType?: "native" | "web";
-  accessType?: 'online' | 'offline';
+  /** Access type for requesting a refresh_token for offline access (desktop only) */
   accessType?: "online" | "offline";
-  prompt?: "none" | "consent" | "select_account";
-  prompt?: "none" | "consent" | "select_account" | "consent select_account" | "select_account consent";
+  /** Specifies whether to prompt the user for re-authentication (desktop only) */
+  prompt?:
+    | "none"
+    | "consent"
+    | "select_account"
+    | "consent select_account"
+    | "select_account consent";
 }
 
 /**

--- a/guest-js/index.ts
+++ b/guest-js/index.ts
@@ -39,6 +39,7 @@ export interface SignInOptions {
   accessType?: 'online' | 'offline';
   accessType?: "online" | "offline";
   prompt?: "none" | "consent" | "select_account";
+  prompt?: "none" | "consent" | "select_account" | "consent select_account" | "select_account consent";
 }
 
 /**

--- a/src/desktop.rs
+++ b/src/desktop.rs
@@ -170,6 +170,10 @@ impl<R: Runtime> GoogleAuth<R> {
             auth_url_builder = auth_url_builder.add_scope(Scope::new(scope));
         }
 
+        if let Some(access_type) = &payload.access_type {
+            auth_url_builder = auth_url_builder.add_extra_param("access_type", access_type);
+        }
+
         let (authorize_url, _csrf_state) = auth_url_builder
             .set_pkce_challenge(pkce_code_challenge)
             .url();

--- a/src/desktop.rs
+++ b/src/desktop.rs
@@ -174,6 +174,10 @@ impl<R: Runtime> GoogleAuth<R> {
             auth_url_builder = auth_url_builder.add_extra_param("access_type", access_type);
         }
 
+        if let Some(prompt) = &payload.prompt {
+            auth_url_builder = auth_url_builder.add_extra_param("prompt", prompt);
+        }
+
         let (authorize_url, _csrf_state) = auth_url_builder
             .set_pkce_challenge(pkce_code_challenge)
             .url();

--- a/src/desktop.rs
+++ b/src/desktop.rs
@@ -224,6 +224,25 @@ impl<R: Runtime> GoogleAuth<R> {
                     crate::Error::NetworkError(format!("Failed to parse redirect URL: {e}"))
                 })?;
 
+            if let Some((_, error_type)) = url.query_pairs().find(|(key, _)| key == "error") {
+                let error_desc = url
+                    .query_pairs()
+                    .find(|(key, _)| key == "error_description")
+                    .map(|(_, v)| v.into_owned())
+                    .unwrap_or_default();
+
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-length: {}\r\n\r\n{}",
+                    success_message.len(),
+                    success_message
+                );
+                stream.get_mut().write_all(response.as_bytes()).await?;
+
+                return Err(crate::Error::AuthenticationFailed(format!(
+                    "Google OAuth error: {error_type} - {error_desc}"
+                )));
+            }
+
             let code = url
                 .query_pairs()
                 .find(|(key, _)| key == "code")

--- a/src/desktop.rs
+++ b/src/desktop.rs
@@ -16,7 +16,9 @@ use url::Url;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpListener;
 
-use crate::models::{RefreshTokenRequest, SignInRequest, SignOutRequest, SignOutResponse};
+use crate::models::{
+    AccessType, Prompt, RefreshTokenRequest, SignInRequest, SignOutRequest, SignOutResponse,
+};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub struct GoogleTokenFields {
@@ -171,11 +173,21 @@ impl<R: Runtime> GoogleAuth<R> {
         }
 
         if let Some(access_type) = &payload.access_type {
-            auth_url_builder = auth_url_builder.add_extra_param("access_type", access_type);
+            let val = match access_type {
+                AccessType::Online => "online",
+                AccessType::Offline => "offline",
+            };
+            auth_url_builder = auth_url_builder.add_extra_param("access_type", val);
         }
 
         if let Some(prompt) = &payload.prompt {
-            auth_url_builder = auth_url_builder.add_extra_param("prompt", prompt);
+            let val = match prompt {
+                Prompt::None => "none",
+                Prompt::Consent => "consent",
+                Prompt::SelectAccount => "select_account",
+                Prompt::ConsentAndSelect => "consent select_account",
+            };
+            auth_url_builder = auth_url_builder.add_extra_param("prompt", val);
         }
 
         let (authorize_url, _csrf_state) = auth_url_builder

--- a/src/models.rs
+++ b/src/models.rs
@@ -10,6 +10,7 @@ pub enum FlowType {
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct SignInRequest {
     pub client_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/models.rs
+++ b/src/models.rs
@@ -8,6 +8,26 @@ pub enum FlowType {
     Web,
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum AccessType {
+    #[default]
+    Online,
+    Offline,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Prompt {
+    #[default]
+    None,
+    Consent,
+    #[serde(rename = "select_account")]
+    SelectAccount,
+    #[serde(rename = "consent select_account", alias = "select_account consent")]
+    ConsentAndSelect,
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
@@ -28,9 +48,9 @@ pub struct SignInRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub flow_type: Option<FlowType>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub access_type: Option<String>,
+    pub access_type: Option<AccessType>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub prompt: Option<String>,
+    pub prompt: Option<Prompt>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/src/models.rs
+++ b/src/models.rs
@@ -28,6 +28,8 @@ pub struct SignInRequest {
     pub flow_type: Option<FlowType>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub access_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/src/models.rs
+++ b/src/models.rs
@@ -26,6 +26,8 @@ pub struct SignInRequest {
     pub success_html_response: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub flow_type: Option<FlowType>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub access_type: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]


### PR DESCRIPTION
### Description
This PR adds `accessType` and `prompt` configuration options to the `SignInRequest` payload. 

Currently, the desktop implementation lacks the ability to request offline access, making the Google OAuth flow return `null` for the `refresh_token`. Since Google handles offline access via a non-standard custom query parameter (`access_type=offline`) rather than standard scopes, exposing these options via the `oauth2` crate's extension mechanism fixes this limitation.

### Changes
- **TypeScript:** Exposed `accessType?: 'online' | 'offline'` and `prompt?: 'none' | 'consent' | 'select_account'` in the sign-in options interface.
- **Rust (Models):** Added `access_type` and `prompt` as optional `String` fields to `SignInRequest` with `#[serde(skip_serializing_if = "Option::is_none")]` attributes to preserve safe backward compatibility and protect native mobile layers from null values.
- **Rust (Desktop):** Implemented `.add_extra_param()` calls inside `desktop.rs` to correctly forward these options to the Google OAuth endpoint.